### PR TITLE
Fix toast context typings and clean UI components

### DIFF
--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -1,51 +1,50 @@
-import { useState } from 'react'
+import { useState, type FormEvent, type ReactNode } from 'react'
+
 import { useToast } from '../hooks/userToast'
 import { api } from '../lib/fetcher'
 
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <label className="mb-3 block">
+      <span className="mb-1 block text-sm opacity-80">{label}</span>
+      {children}
+    </label>
+  )
+}
 
 export default function FormDemo() {
-const [name, setName] = useState('')
-const [email, setEmail] = useState('')
-const { push } = useToast()
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const { push } = useToast()
 
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    try {
+      await api('/echo', { method: 'POST', body: JSON.stringify({ name, email }) })
+      push('Guardado')
+    } catch (err) {
+      push('Error al guardar')
+    }
+  }
 
-const onSubmit = async (e: React.FormEvent) => {
-e.preventDefault()
-try {
-await api('/echo', { method: 'POST', body: JSON.stringify({ name, email }) })
-push('Guardado')
-} catch (err) {
-push('Error al guardar')
-}
-}
-
-
-const Field = (props: { label: string; children: React.ReactNode }) => (
-<label className="mb-3 block">
-<span className="mb-1 block text-sm opacity-80">{props.label}</span>
-{props.children}
-</label>
-)
-
-
-return (
-<form onSubmit={onSubmit} className="space-y-4">
-<Field label="Nombre">
-<input
-className="w-full rounded border bg-transparent px-3 py-2 outline-none focus:ring"
-value={name}
-onChange={(e) => setName(e.target.value)}
-/>
-</Field>
-<Field label="Email">
-<input
-type="email"
-className="w-full rounded border bg-transparent px-3 py-2 outline-none focus:ring"
-value={email}
-onChange={(e) => setEmail(e.target.value)}
-/>
-</Field>
-<button className="rounded bg-slate-900 px-4 py-2 text-white dark:bg-slate-700">Guardar</button>
-</form>
-)
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <Field label="Nombre">
+        <input
+          className="w-full rounded border bg-transparent px-3 py-2 outline-none focus:ring"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+        />
+      </Field>
+      <Field label="Email">
+        <input
+          type="email"
+          className="w-full rounded border bg-transparent px-3 py-2 outline-none focus:ring"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+        />
+      </Field>
+      <button className="rounded bg-slate-900 px-4 py-2 text-white dark:bg-slate-700">Guardar</button>
+    </form>
+  )
 }

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,16 +1,17 @@
-import { PropsWithChildren } from 'react'
-
+import type { PropsWithChildren } from 'react'
 
 type Props = PropsWithChildren<{ open: boolean; title?: string; onClose: () => void }>
+
 export default function Modal({ open, title, onClose, children }: Props) {
-if (!open) return null
-    return (
-        <div className="fixed inset-0 z-50 flex items-center justify-center">
-        <div className="absolute inset-0 bg-black/30" onClick={onClose} />
-        <div className="relative z-10 w-full max-w-lg rounded-lg bg-white p-4 shadow-lg dark:bg-slate-800">
-            {title && <h3 className="mb-2 text-lg font-semibold">{title}</h3>}
-            {children}
-        </div>
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/30" onClick={onClose} />
+      <div className="relative z-10 w-full max-w-lg rounded-lg bg-white p-4 shadow-lg dark:bg-slate-800">
+        {title && <h3 className="mb-2 text-lg font-semibold">{title}</h3>}
+        {children}
+      </div>
     </div>
-    )
+  )
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,23 +1,22 @@
-import { FC } from 'react'
-
-
 type Props = { theme: 'light' | 'dark'; onToggleTheme: () => void }
 
-
-const Navbar: FC<Props> = ({ theme, onToggleTheme }) => (
-<header className="sticky top-0 z-10 border-b border-slate-200/20 backdrop-blur bg-white/70 dark:bg-slate-900/70">
-<nav className="max-w-6xl mx-auto flex items-center justify-between p-3">
-<div className="font-bold">demo-base-ui</div>
-<div className="flex gap-3 items-center">
-<a className="text-sm" href="#">Home</a>
-<a className="text-sm" href="#">Demo</a>
-<button className="text-sm px-3 py-1 rounded border" onClick={onToggleTheme}>
-{theme === 'dark' ? 'Claro' : 'Oscuro'}
-</button>
-</div>
-</nav>
-</header>
-)
-
-
-export default Navbar
+export default function Navbar({ theme, onToggleTheme }: Props) {
+  return (
+    <header className="sticky top-0 z-10 border-b border-slate-200/20 bg-white/70 backdrop-blur dark:bg-slate-900/70">
+      <nav className="mx-auto flex max-w-6xl items-center justify-between p-3">
+        <div className="font-bold">demo-base-ui</div>
+        <div className="flex items-center gap-3">
+          <a className="text-sm" href="#">
+            Home
+          </a>
+          <a className="text-sm" href="#">
+            Demo
+          </a>
+          <button className="rounded border px-3 py-1 text-sm" onClick={onToggleTheme}>
+            {theme === 'dark' ? 'Claro' : 'Oscuro'}
+          </button>
+        </div>
+      </nav>
+    </header>
+  )
+}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,28 +1,30 @@
-import { useMemo, useState } from 'react'
-import type { PropsWithChildren } from 'react'
-import { ToastCtx } from './ToastCtx'
+import { useCallback, useMemo, useState, type PropsWithChildren } from 'react'
+
+import { ToastCtx, type ToastContextValue } from './ToastCtx'
 
 type ToastMsg = { id: number; text: string }
 
-
 export default function ToastProvider({ children }: PropsWithChildren) {
-const [items, setItems] = useState<ToastMsg[]>([])
-const push = (text: string) => {
-const id = Date.now()
-setItems((p) => [...p, { id, text }])
-setTimeout(() => setItems((p) => p.filter((i) => i.id !== id)), 3000)
-}
-const value = useMemo(() => ({ push }), [])
-return (
-<ToastCtx.Provider value={value}>
-{children}
-<div className="fixed bottom-4 right-4 space-y-2">
-{items.map((i) => (
-<div key={i.id} className="px-3 py-2 rounded shadow bg-slate-800 text-white">
-{i.text}
-</div>
-))}
-</div>
-</ToastCtx.Provider>
-)
+  const [items, setItems] = useState<ToastMsg[]>([])
+
+  const push = useCallback<ToastContextValue['push']>((text) => {
+    const id = Date.now()
+    setItems((previous) => [...previous, { id, text }])
+    setTimeout(() => setItems((previous) => previous.filter((item) => item.id !== id)), 3000)
+  }, [])
+
+  const value = useMemo(() => ({ push }), [push])
+
+  return (
+    <ToastCtx.Provider value={value}>
+      {children}
+      <div className="fixed bottom-4 right-4 space-y-2">
+        {items.map((item) => (
+          <div key={item.id} className="rounded bg-slate-800 px-3 py-2 text-white shadow">
+            {item.text}
+          </div>
+        ))}
+      </div>
+    </ToastCtx.Provider>
+  )
 }

--- a/src/components/ToastCtx.ts
+++ b/src/components/ToastCtx.ts
@@ -1,0 +1,7 @@
+import { createContext } from 'react'
+
+export type ToastContextValue = {
+  push: (text: string) => void
+}
+
+export const ToastCtx = createContext<ToastContextValue | undefined>(undefined)

--- a/src/hooks/userToast.ts
+++ b/src/hooks/userToast.ts
@@ -1,3 +1,11 @@
 import { useContext } from 'react'
-import { ToastCtx } from '../components/Toast'
-export const useToast = () => useContext(ToastCtx)
+
+import { ToastCtx } from '../components/ToastCtx'
+
+export const useToast = () => {
+  const context = useContext(ToastCtx)
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider')
+  }
+  return context
+}

--- a/src/pages/Demo.tsx
+++ b/src/pages/Demo.tsx
@@ -1,60 +1,60 @@
 import { useEffect, useState } from 'react'
-import DataTable from '../components/Datatable'
+
+import DataTable from '../components/DataTable'
 import FormDemo from '../components/Form'
-import Modal from '../components/Modal'
 import Loader from '../components/Loader'
+import Modal from '../components/Modal'
 import { api } from '../lib/fetcher'
 
+type UserRow = { id: number; name: string; email: string }
 
 export default function Demo() {
-const [open, setOpen] = useState(false)
-const [rows, setRows] = useState<{ id: number; name: string; email: string }[]>([])
-const [loading, setLoading] = useState(false)
+  const [open, setOpen] = useState(false)
+  const [rows, setRows] = useState<UserRow[]>([])
+  const [loading, setLoading] = useState(false)
 
+  useEffect(() => {
+    void (async () => {
+      setLoading(true)
+      try {
+        const data = await api<UserRow[]>('/users')
+        setRows(data)
+      } catch {
+        setRows([
+          { id: 1, name: 'Ana', email: 'ana@mail.com' },
+          { id: 2, name: 'Luis', email: 'luis@mail.com' },
+        ])
+      } finally {
+        setLoading(false)
+      }
+    })()
+  }, [])
 
-useEffect(() => {
-;(async () => {
-setLoading(true)
-try {
-const data = await api<{ id: number; name: string; email: string }[]>('/users')
-setRows(data)
-} catch {
-setRows([
-{ id: 1, name: 'Ana', email: 'ana@mail.com' },
-{ id: 2, name: 'Luis', email: 'luis@mail.com' },
-])
-} finally {
-setLoading(false)
-}
-})()
-}, [])
+  return (
+    <section className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Demo base</h1>
+        <button className="rounded border px-3 py-1" onClick={() => setOpen(true)}>
+          Nuevo
+        </button>
+      </div>
 
+      {loading ? (
+        <Loader />
+      ) : (
+        <DataTable
+          columns={[
+            { key: 'id', title: 'ID' },
+            { key: 'name', title: 'Nombre' },
+            { key: 'email', title: 'Email' },
+          ]}
+          data={rows}
+        />
+      )}
 
-return (
-<section className="space-y-6">
-<div className="flex items-center justify-between">
-<h1 className="text-2xl font-bold">Demo base</h1>
-<button className="rounded border px-3 py-1" onClick={() => setOpen(true)}>Nuevo</button>
-</div>
-
-
-{loading ? (
-<Loader />
-) : (
-<DataTable
-columns={[
-{ key: 'id', title: 'ID' },
-{ key: 'name', title: 'Nombre' },
-{ key: 'email', title: 'Email' },
-]}
-data={rows}
-/>
-)}
-
-
-<Modal open={open} title="Crear registro" onClose={() => setOpen(false)}>
-<FormDemo />
-</Modal>
-</section>
-)
+      <Modal open={open} title="Crear registro" onClose={() => setOpen(false)}>
+        <FormDemo />
+      </Modal>
+    </section>
+  )
 }


### PR DESCRIPTION
## Summary
- add an explicit toast context module and hook guard to fix TypeScript errors
- refactor form, modal, navbar, and demo page markup for consistent structure and correct imports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e243fb3f408333ad85e3b765ea5820